### PR TITLE
RuboCop 1.22.1

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,6 +1,6 @@
 rubocop:
   config_file: .rubocop.yml
-  version: 0.72.0
+  version: 1.22.1
 coffeescript:
   config_file: coffeescript.json
 scss:
@@ -15,4 +15,3 @@ stylelint:
   config_file: .stylelintrc.json
   version: 13.2.1
   enabled: true
-

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,169 +1,46 @@
+inherit_mode:
+  merge:
+    - Exclude
+
 AllCops:
   NewCops: enable
-  RubyInterpreters:
-    - ruby
-    - macruby
-    - rake
-    - jruby
-    - rbx
-  # Include common Ruby source files.
-  Include:
-    - '**/*.rb'
-    - '**/*.arb'
-    - '**/*.axlsx'
-    - '**/*.builder'
-    - '**/*.fcgi'
-    - '**/*.gemfile'
-    - '**/*.gemspec'
-    - '**/*.god'
-    - '**/*.jb'
-    - '**/*.jbuilder'
-    - '**/*.mspec'
-    - '**/*.opal'
-    - '**/*.pluginspec'
-    - '**/*.podspec'
-    - '**/*.rabl'
-    - '**/*.rake'
-    - '**/*.rbuild'
-    - '**/*.rbw'
-    - '**/*.rbx'
-    - '**/*.ru'
-    - '**/*.ruby'
-    - '**/*.spec'
-    - '**/*.thor'
-    - '**/*.watchr'
-    - '**/.irbrc'
-    - '**/.pryrc'
-    - '**/buildfile'
-    - '**/Appraisals'
-    - '**/Berksfile'
-    - '**/Brewfile'
-    - '**/Buildfile'
-    - '**/Capfile'
-    - '**/Cheffile'
-    - '**/Dangerfile'
-    - '**/Deliverfile'
-    - '**/Fastfile'
-    - '**/*Fastfile'
-    - '**/Gemfile'
-    - '**/Guardfile'
-    - '**/Jarfile'
-    - '**/Mavenfile'
-    - '**/Podfile'
-    - '**/Puppetfile'
-    - '**/Rakefile'
-    - '**/Snapfile'
-    - '**/Thorfile'
-    - '**/Vagabondfile'
-    - '**/Vagrantfile'
   Exclude:
-    - 'node_modules/**/*'
-    - 'vendor/**/*'
-    - '.git/**/*'
     - 'db/schema.rb'
     - 'archive/**/*'
     - 'client/**/*'
   DisplayCopNames: false
-  StyleGuideCopsOnly: false
+  SuggestExtensions: false
   TargetRubyVersion: 3.0.0
 Layout/ParameterAlignment:
-  Description: Align the parameters of a method call if they span more than one line.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-double-indent
-  Enabled: true
   EnforcedStyle: with_fixed_indentation
-  SupportedStyles:
-    - with_first_parameter
-    - with_fixed_indentation
 Layout/MultilineMethodCallIndentation:
-  Description: Checks indentation of method calls with the dot operator
-    that span more than one line.
-  Enabled: true
   EnforcedStyle: indented
-  SupportedStyles:
-    - aligned
-    - indented
 Layout/MultilineOperationIndentation:
-  Description: Checks indentation of binary operations that span more than one line.
-  Enabled: true
   EnforcedStyle: indented
-  SupportedStyles:
-    - aligned
-    - indented
-Layout/DotPosition:
-  Description: Checks the position of the dot in multi-line method calls.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
-  Enabled: true
-  EnforcedStyle: leading
-  SupportedStyles:
-    - leading
-    - trailing
 Style/IfUnlessModifier:
-  Description: Favor modifier if/unless usage when you have a single-line body.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
   Enabled: false
 Style/RegexpLiteral:
-  Enabled: true
   EnforcedStyle: mixed
-  # slashes: Always use slashes.
-  # percent_r: Always use %r.
-  # mixed: Use slashes on single-line regexes, and %r on multi-line regexes.
-  SupportedStyles:
-    - slashes
-    - percent_r
-    - mixed
-  # If false, the cop will always recommend using %r if one or more slashes
-  # are found in the regexp string.
-  AllowInnerSlashes: true
-Style/StringLiterals:
-  Description: Checks if uses of quotes match the configured preference.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-string-literals
-  Enabled: true
-  EnforcedStyle: single_quotes
-  SupportedStyles:
-    - single_quotes
-    - double_quotes
-Style/TrailingCommaInArguments:
-  Description: Checks for trailing comma in parameter lists and literals.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
-  Enabled: true
-  EnforcedStyleForMultiline: no_comma
 Style/WhileUntilModifier:
-  Description: Favor modifier while/until usage when you have a single-line body.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#while-as-a-modifier
   Enabled: false
 Style/AccessModifierDeclarations:
-  Enabled: false  
+  Enabled: false
 Metrics/AbcSize:
-  Description: A calculated magnitude based on number of assignments, branches, and
-    conditions.
-  Enabled: true
   Max: 20
 Layout/LineLength:
-  Description: Limit lines to 100 characters.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#100-character-limits
-  Enabled: true
   Max: 100
-  AllowURI: true
-  URISchemes:
-    - http
-    - https
 Metrics/MethodLength:
-  Description: Avoid methods longer than 10 lines of code.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#short-methods
-  Enabled: true
   CountComments: true
   Max: 30
   Exclude:
     - "spec/**/*"
 Metrics/BlockLength:
-  CountComments: false  # count full line comments?
-  Max: 25
   Exclude:
     - 'Rakefile'
     - '**/*.rake'
     - 'spec/**/*.rb'
+    - '**/*.gemspec'
 Layout/ExtraSpacing:
-  Description: Do not use unnecessary spacing.
   Enabled: false
 Style/SymbolArray:
   EnforcedStyle: brackets


### PR DESCRIPTION
Update to latest RuboCop ([supported linters](http://help.houndci.com/en/articles/2461415-supported-linters))